### PR TITLE
adds return codes and documentation to ccnl-cs

### DIFF
--- a/src/ccnl-cs/include/ccnl-cs.h
+++ b/src/ccnl-cs/include/ccnl-cs.h
@@ -21,8 +21,21 @@
 #ifndef CCNL_CS
 #define CCNL_CS
 
-#include "stdlib.h"
-#include "stdint.h"
+#include <limits.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+/**
+ * @brief Provides status codes for content store operations
+ */
+typedef enum {
+    CS_OPERATION_WAS_SUCCESSFUL = 0, /**< operation was successfull */
+    CS_OPTIONS_ARE_NULL = -1,        /**< \ref ccnl_cs_ops_t are NULL */
+    CS_NAME_IS_INVALID = -2,         /**< name is invalid or NULL */
+    CS_CONTENT_IS_INVALID = -3,      /**< content is invalid or NULL */
+    
+    CS_DO_NOT_USE = INT_MAX          /**< set the enum to a fixed width, do not use! */
+} ccnl_cs_status_t;
 
 /**
  * @brief An abstract representation of an ICN name 
@@ -90,7 +103,7 @@ ccnl_cs_init(ccnl_cs_ops_t *ops,
  * @return -2 An invalid \ref ccnl_cs_name_t struct was passed to the function (e.g. \p name is NULL)
  * @return -3 An invalid \ref ccnl_cs_content_t struct was passed to the function (e.g. \p content is NULL)
  */
-int
+ccnl_cs_status_t
 ccnl_cs_add(ccnl_cs_ops_t *ops,
             const ccnl_cs_name_t *name,
             const ccnl_cs_content_t *content);
@@ -119,7 +132,7 @@ ccnl_cs_lookup(ccnl_cs_ops_t *ops,
  * @return -1 An invalid \ref ccnl_cs_op_t struct was passed to the function (e.g. \p ops is NULL)
  * @return -2 An invalid \ref ccnl_cs_name_t struct was passed to the function (e.g. \p name is NULL)
  */
-int
+ccnl_cs_status_t
 ccnl_cs_remove(ccnl_cs_ops_t *ops,
                const ccnl_cs_name_t *name);
 

--- a/src/ccnl-cs/include/ccnl-cs.h
+++ b/src/ccnl-cs/include/ccnl-cs.h
@@ -61,7 +61,7 @@ typedef int (*ccnl_cs_op_add_t)(const ccnl_cs_name_t *name, const ccnl_cs_conten
 /**
  * Type definition for the function pointer to the lookup function
  */
-typedef ccnl_cs_content_t *(*ccnl_cs_op_lookup_t)(const ccnl_cs_name_t *name);
+typedef int (*ccnl_cs_op_lookup_t)(const ccnl_cs_name_t *name, ccnl_cs_content_t *content);
 
 /**
  * Type definition for the function pointer to the remove function
@@ -113,14 +113,17 @@ ccnl_cs_add(ccnl_cs_ops_t *ops,
  *
  * @param[in] ops Data structure which holds the function pointer to the lookup function
  * @param[in] name The name of the content which is about to searched in the content store
+ * @param[out] content If the lookup was successfull, the variable contains the result
  *
- * @return 0 The content was added successfully to the content store
+ * @return 0 The content was found in the content store
  * @return -1 An invalid \ref ccnl_cs_op_t struct was passed to the function (e.g. \p ops is NULL)
  * @return -2 An invalid \ref ccnl_cs_name_t struct was passed to the function (e.g. \p name is NULL)
+ * @return -2 An invalid \ref ccnl_cs_content_t struct was passed to the function (e.g. \p content is NULL)
  */
-ccnl_cs_content_t *
+ccnl_cs_status_t
 ccnl_cs_lookup(ccnl_cs_ops_t *ops,
-               const ccnl_cs_name_t *name);
+               const ccnl_cs_name_t *name,
+               ccnl_cs_content_t *content);
 
 /**
  * @brief Removes an item from the content store 

--- a/src/ccnl-cs/include/ccnl-cs.h
+++ b/src/ccnl-cs/include/ccnl-cs.h
@@ -1,8 +1,9 @@
-/*
- * @file ccnl-cs.h
- * @brief CCN lite - Content Store Implementation
+/**
+ * @f ccnl-cs.h
+ * @b CCN lite - Content store implementation
  *
  * Copyright (C) 2018 HAW Hamburg
+ * Copyright (C) 2018 MSA Safety 
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -23,40 +24,101 @@
 #include "stdlib.h"
 #include "stdint.h"
 
+/**
+ * @brief An abstract representation of an ICN name 
+ */
 typedef struct {
-    uint8_t *name;
-    unsigned namelen;
+    uint8_t *name;    /**< The name itself */
+    uint32_t length;  /**< The length of the name */
 } ccnl_cs_name_t;
 
+/**
+ * @brief An abstract representation of ICN content
+ */
 typedef struct {
-    uint8_t *content;
-    unsigned contlen;
+    uint8_t *content; /**< A byte representation of the content */
+    uint32_t length;  /**< The size of the content */
 } ccnl_cs_content_t;
 
+/**
+ * Type definition for the function pointer to the add function
+ */
 typedef int (*ccnl_cs_op_add_t)(const ccnl_cs_name_t *name, const ccnl_cs_content_t *content);
+
+/**
+ * Type definition for the function pointer to the lookup function
+ */
 typedef ccnl_cs_content_t *(*ccnl_cs_op_lookup_t)(const ccnl_cs_name_t *name);
+
+/**
+ * Type definition for the function pointer to the remove function
+ */
 typedef int (*ccnl_cs_op_remove_t)(const ccnl_cs_name_t *name);
 
+/**
+ * @brief Holds function pointers to concrete implementations of a content store
+ */
 typedef struct {
-    ccnl_cs_op_add_t add;
-    ccnl_cs_op_lookup_t lookup;
-    ccnl_cs_op_remove_t remove;
+    ccnl_cs_op_add_t add;       /**< Function pointer to the add function */
+    ccnl_cs_op_lookup_t lookup; /**< Function pointer to the lookup function */
+    ccnl_cs_op_remove_t remove; /**< Function pointer to the remove function */
 } ccnl_cs_ops_t;
 
+/**
+ * @brief Sets the given function pointers to \p ops
+ *
+ * @param[out] ops The data structure to initialize 
+ * @param[in] add_fun A function pointer to the add function
+ * @param[in] lookup_fun A function pointer to the lookup function
+ * @param[in] remove_fun A function pointer to the remove function
+ */
 void
 ccnl_cs_init(ccnl_cs_ops_t *ops,
              ccnl_cs_op_add_t add_fun,
              ccnl_cs_op_lookup_t lookup_fun,
              ccnl_cs_op_remove_t remove_fun);
+
+/**
+ * @brief Adds an item to the content store
+ *
+ * @param[in] ops Data structure which holds the function pointer to the add function
+ * @param[in] name The name of the content
+ * @param[in] content The content to add
+ *
+ * @return 0 The content was added successfully to the content store
+ * @return -1 An invalid \ref ccnl_cs_op_t struct was passed to the function (e.g. \p ops is NULL)
+ * @return -2 An invalid \ref ccnl_cs_name_t struct was passed to the function (e.g. \p name is NULL)
+ * @return -3 An invalid \ref ccnl_cs_content_t struct was passed to the function (e.g. \p content is NULL)
+ */
 int
 ccnl_cs_add(ccnl_cs_ops_t *ops,
             const ccnl_cs_name_t *name,
             const ccnl_cs_content_t *content);
 
+/**
+ * @brief Searches the content store for the specified item
+ *
+ * @param[in] ops Data structure which holds the function pointer to the lookup function
+ * @param[in] name The name of the content which is about to searched in the content store
+ *
+ * @return 0 The content was added successfully to the content store
+ * @return -1 An invalid \ref ccnl_cs_op_t struct was passed to the function (e.g. \p ops is NULL)
+ * @return -2 An invalid \ref ccnl_cs_name_t struct was passed to the function (e.g. \p name is NULL)
+ */
 ccnl_cs_content_t *
 ccnl_cs_lookup(ccnl_cs_ops_t *ops,
                const ccnl_cs_name_t *name);
 
+/**
+ * @brief Removes an item from the content store 
+ *
+ * @param[in] ops Data structure which holds the function pointer to the remove function
+ * @param[in] name The name of the content to be removed
+ *
+ * @return 0 The content was removed successfully from the content store
+ * @return -1 An invalid \ref ccnl_cs_op_t struct was passed to the function (e.g. \p ops is NULL)
+ * @return -2 An invalid \ref ccnl_cs_name_t struct was passed to the function (e.g. \p name is NULL)
+ */
 int
 ccnl_cs_remove(ccnl_cs_ops_t *ops,
                const ccnl_cs_name_t *name);

--- a/src/ccnl-cs/src/ccnl-cs-simple.c
+++ b/src/ccnl-cs/src/ccnl-cs-simple.c
@@ -28,9 +28,10 @@ static int add(const ccnl_cs_name_t *name, const ccnl_cs_content_t *content) {
     return 0;
 }
 
-static ccnl_cs_content_t *lookup(const ccnl_cs_name_t *name) {
+static int lookup(const ccnl_cs_name_t *name, ccnl_cs_content_t *content) {
     (void) name;
-    return NULL;
+    (void) content;
+    return 0;
 }
 
 static int remove(const ccnl_cs_name_t *name) {

--- a/src/ccnl-cs/src/ccnl-cs.c
+++ b/src/ccnl-cs/src/ccnl-cs.c
@@ -54,10 +54,24 @@ ccnl_cs_add(ccnl_cs_ops_t *ops,
     return result;
 }
 
-ccnl_cs_content_t *
+ccnl_cs_status_t
 ccnl_cs_lookup(ccnl_cs_ops_t *ops,
-               const ccnl_cs_name_t *name) {
-    return ops->lookup(name);
+               const ccnl_cs_name_t *name, ccnl_cs_content_t *content) {
+    int result = CS_CONTENT_IS_INVALID;
+
+    if (ops) {
+        if (name) {
+            if (content) {
+                return ops->lookup(name, content);
+            }
+        } else {
+            result = CS_NAME_IS_INVALID;
+        }
+    } else {
+        result = CS_OPTIONS_ARE_NULL;
+    }
+
+    return result;
 }
 
 ccnl_cs_status_t

--- a/src/ccnl-cs/src/ccnl-cs.c
+++ b/src/ccnl-cs/src/ccnl-cs.c
@@ -3,6 +3,7 @@
  * @brief CS - Content Store
  *
  * Copyright (C) 2018 HAW Hamburg
+ * Copyright (C) 2018 MSA Safety
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -17,7 +18,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  */
-
 #include "ccnl-cs.h"
 
 void
@@ -37,21 +37,41 @@ int
 ccnl_cs_add(ccnl_cs_ops_t *ops,
             const ccnl_cs_name_t *name,
             const ccnl_cs_content_t *content) {
+    int result = -3;
 
-    return ops->add(name, content);
+    if (ops) {
+        if (name) {
+            if (content) {
+                return ops->add(name, content); 
+            }
+        } else {
+            result = -2;
+        }
+    } else {
+        result = -1;
+    }
 
+    return result;
 }
 
 ccnl_cs_content_t *
 ccnl_cs_lookup(ccnl_cs_ops_t *ops,
                const ccnl_cs_name_t *name) {
-
     return ops->lookup(name);
 }
 
 int
 ccnl_cs_remove(ccnl_cs_ops_t *ops,
                const ccnl_cs_name_t *name) {
+    int result = -2;
 
-    return ops->remove(name);
+    if (ops) {
+        if (name) {
+            return ops->remove(name);
+        }
+    } else {
+        result = -1;
+    }
+
+    return result;
 }

--- a/src/ccnl-cs/src/ccnl-cs.c
+++ b/src/ccnl-cs/src/ccnl-cs.c
@@ -33,11 +33,11 @@ ccnl_cs_init(ccnl_cs_ops_t *ops,
     return;
 }
 
-int
+ccnl_cs_status_t
 ccnl_cs_add(ccnl_cs_ops_t *ops,
             const ccnl_cs_name_t *name,
             const ccnl_cs_content_t *content) {
-    int result = -3;
+    int result = CS_CONTENT_IS_INVALID;
 
     if (ops) {
         if (name) {
@@ -45,10 +45,10 @@ ccnl_cs_add(ccnl_cs_ops_t *ops,
                 return ops->add(name, content); 
             }
         } else {
-            result = -2;
+            result = CS_NAME_IS_INVALID;
         }
     } else {
-        result = -1;
+        result = CS_OPTIONS_ARE_NULL;
     }
 
     return result;
@@ -60,17 +60,17 @@ ccnl_cs_lookup(ccnl_cs_ops_t *ops,
     return ops->lookup(name);
 }
 
-int
+ccnl_cs_status_t
 ccnl_cs_remove(ccnl_cs_ops_t *ops,
                const ccnl_cs_name_t *name) {
-    int result = -2;
+    int result = CS_NAME_IS_INVALID;
 
     if (ops) {
         if (name) {
             return ops->remove(name);
         }
     } else {
-        result = -1;
+        result = CS_OPTIONS_ARE_NULL;
     }
 
     return result;

--- a/test/ccnl-cs/test_cs.c
+++ b/test/ccnl-cs/test_cs.c
@@ -1,21 +1,133 @@
+/**
+ * @file test-cs.c
+ * @brief CCN lite - Tests for content store implementation
+ *
+ * Copyright (C) 2018 MSA Safety
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <stdint.h>
+#include <string.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>
 #include <cmocka.h>
  
 #include "ccnl-cs.h"
+
+
+static int setup(void **state) {
+     ccnl_cs_ops_t content_store;
+     /** TODO: set function pointers */
+
+     state = (void*)&content_store;
+
+     return 0;
+}
+
+static int teardown(void **state) {
+
+     return 0;
+}
  
 void test1()
 {
   int result = 0;
   assert_int_equal(result, 0);
 }
+
+void test_ccnl_cs_remove_invalid_struct()
+{
+    /** build up our ccnl_cs_name_t struct */
+    uint8_t _size = 10;
+    uint8_t _name[_size];
+    memset(&(_name[0]), 0x42, _size);  
+
+    /** set the name */
+    ccnl_cs_name_t name;
+    /** TODO: that's a bit hard to read -> fix */
+    name.name = &(_name[0]);
+    name.namelen = _size;
+            
+    int result = ccnl_cs_remove(NULL, &name);
+    /* if we pass an invalid ccnl_cs_ops_t array, call should fail */
+    assert_int_equal(result, 0);
+}
+
+void test_ccnl_cs_remove_wrong_name_size(void **state)
+{
+    /* retrieve implementation */
+    ccnl_cs_ops_t *content_store_impl = (ccnl_cs_ops_t*)state;
+    /* build up our ccnl_cs_name_t struct */
+    uint8_t _size = 10;
+    uint8_t _name[_size];
+    memset(&(_name[0]), 0x42, _size);  
+
+    /** set the name */
+    ccnl_cs_name_t name;
+    /** TODO: that's a bit hard to read -> fix */
+    name.name = &(_name[0]);
+    /** what happens if we set the size to 0? */
+    name.namelen = 0;
+            
+    /* TODO: pass actual valid first parameter */
+    int result = ccnl_cs_remove(content_store_impl, &name);
+    /* if we pass an invalid ccnl_cs_ops_t array, call should fail */
+    assert_int_equal(result, 0);
+
+    /** what happens if we set the size to two-times the actual size? */
+    name.namelen = 2 * _size;
+    /* TODO: pass actual valid first parameter */
+    result = ccnl_cs_remove(content_store_impl, &name);
+    /* if we pass an invalid ccnl_cs_ops_t array, call should fail */
+    assert_int_equal(result, 0);
+}
+
+void test_ccnl_cs_remove_partially_valid_structs(void **state)
+{
+    /* retrieve implementation */
+    ccnl_cs_ops_t *content_store_impl = (ccnl_cs_ops_t*)state;
+
+    /** leave the member 'name' uninitialized */
+    ccnl_cs_name_t name;
+    /** but give it a size */
+    name.namelen = 256;
+
+    int result = ccnl_cs_remove(content_store_impl, &name);
+    /* call should fail */
+    assert_int_equal(result, 0);
+
+    /* okay, let's set the name to NULL, is a check performed? */
+    name.name = NULL;
+
+    result = ccnl_cs_remove(content_store_impl, &name);
+    /* call should fail */
+    assert_int_equal(result, 0);
+}
+
  
 int main(void)
 {
-  const UnitTest tests[] = {
-    unit_test(test1),
-  };
- 
-  return run_tests(tests);
+     const UnitTest tests[] = {
+         unit_test(test1),
+    /*
+         unit_test(test_ccnl_cs_remove_invalid_struct),
+         unit_test(test_ccnl_cs_remove_invalid_name),
+         unit_test(test_ccnl_cs_remove_wrong_name_size, setup, NULL),
+         unit_test(test_ccnl_cs_remove_partially_valid_structs, setup, NULL),
+    */
+     };
+    
+     return run_tests(tests); 
 }

--- a/test/ccnl-cs/test_cs.c
+++ b/test/ccnl-cs/test_cs.c
@@ -47,7 +47,7 @@ void test1()
   assert_int_equal(result, 0);
 }
 
-void test_ccnl_cs_remove_invalid_struct()
+void test_ccnl_cs_add_invalid_parameters()
 {
     /** build up our ccnl_cs_name_t struct */
     uint8_t _size = 10;
@@ -58,11 +58,88 @@ void test_ccnl_cs_remove_invalid_struct()
     ccnl_cs_name_t name;
     /** TODO: that's a bit hard to read -> fix */
     name.name = &(_name[0]);
-    name.namelen = _size;
+    name.length = _size;
+            
+    ccnl_cs_content_t content;
+    int result = ccnl_cs_add(NULL, &name, &content);
+    /* if we pass an invalid ccnl_cs_ops_t array, call should fail */
+    assert_int_equal(result, -1);
+
+    /* we don't initialize the function pointers */
+    ccnl_cs_ops_t options;
+
+    result = ccnl_cs_add(&options, NULL, &content);
+    /* if we pass an invalid name, call should fail */
+    assert_int_equal(result, -2);
+
+    result = ccnl_cs_add(&options, &name, NULL);
+    /* if we pass an invalid content object, call should fail */
+    assert_int_equal(result, -3);
+}
+
+void test_ccnl_cs_add_successful()
+{
+    /** build up our ccnl_cs_name_t struct */
+    uint8_t _size = 10;
+    uint8_t _name[_size];
+    memset(&(_name[0]), 0x42, _size);  
+
+    /** set the name */
+    ccnl_cs_name_t name;
+    /** TODO: that's a bit hard to read -> fix */
+    name.name = &(_name[0]);
+    name.length = _size;
+    ccnl_cs_content_t content;
+    //TODO    
+    int result = ccnl_cs_add(NULL, &name, &content);
+    /* if we pass an invalid ccnl_cs_ops_t array, call should fail */
+    assert_int_equal(result, 0);
+}
+
+void test_ccnl_cs_add_unsuccessful()
+{
+    /** build up our ccnl_cs_name_t struct */
+    uint8_t _size = 10;
+    uint8_t _name[_size];
+    memset(&(_name[0]), 0x42, _size);  
+
+    /** set the name */
+    ccnl_cs_name_t name;
+    /** TODO: that's a bit hard to read -> fix */
+    name.name = &(_name[0]);
+    name.length = _size;
+     ccnl_cs_content_t content;
+    //TODO    
+    int result = ccnl_cs_add(NULL, &name, &content);
+    /* if we pass an invalid ccnl_cs_ops_t array, call should fail */
+    assert_int_equal(result, 0);
+
+    // and now try to add the same content again which should fail
+
+}
+
+void test_ccnl_cs_remove_invalid_parameters()
+{
+    /** build up our ccnl_cs_name_t struct */
+    uint8_t _size = 10;
+    uint8_t _name[_size];
+    memset(&(_name[0]), 0x42, _size);  
+
+    /** set the name */
+    ccnl_cs_name_t name;
+    name.name = &(_name[0]);
+    name.length = _size;
             
     int result = ccnl_cs_remove(NULL, &name);
     /* if we pass an invalid ccnl_cs_ops_t array, call should fail */
-    assert_int_equal(result, 0);
+    assert_int_equal(result, -1);
+
+    /* we don't set function pointers */
+    ccnl_cs_ops_t options;
+
+    result = ccnl_cs_remove(&options, NULL);
+    /* if we pass an invalid name, call should fail */
+    assert_int_equal(result, -2);
 }
 
 void test_ccnl_cs_remove_wrong_name_size(void **state)
@@ -79,7 +156,7 @@ void test_ccnl_cs_remove_wrong_name_size(void **state)
     /** TODO: that's a bit hard to read -> fix */
     name.name = &(_name[0]);
     /** what happens if we set the size to 0? */
-    name.namelen = 0;
+    name.length = 0;
             
     /* TODO: pass actual valid first parameter */
     int result = ccnl_cs_remove(content_store_impl, &name);
@@ -87,7 +164,7 @@ void test_ccnl_cs_remove_wrong_name_size(void **state)
     assert_int_equal(result, 0);
 
     /** what happens if we set the size to two-times the actual size? */
-    name.namelen = 2 * _size;
+    name.length = 2 * _size;
     /* TODO: pass actual valid first parameter */
     result = ccnl_cs_remove(content_store_impl, &name);
     /* if we pass an invalid ccnl_cs_ops_t array, call should fail */
@@ -102,7 +179,7 @@ void test_ccnl_cs_remove_partially_valid_structs(void **state)
     /** leave the member 'name' uninitialized */
     ccnl_cs_name_t name;
     /** but give it a size */
-    name.namelen = 256;
+    name.length = 256;
 
     int result = ccnl_cs_remove(content_store_impl, &name);
     /* call should fail */
@@ -121,8 +198,9 @@ int main(void)
 {
      const UnitTest tests[] = {
          unit_test(test1),
+         unit_test(test_ccnl_cs_remove_invalid_parameters),
+         unit_test(test_ccnl_cs_add_invalid_parameters),
     /*
-         unit_test(test_ccnl_cs_remove_invalid_struct),
          unit_test(test_ccnl_cs_remove_invalid_name),
          unit_test(test_ccnl_cs_remove_wrong_name_size, setup, NULL),
          unit_test(test_ccnl_cs_remove_partially_valid_structs, setup, NULL),

--- a/test/ccnl-cs/test_cs.c
+++ b/test/ccnl-cs/test_cs.c
@@ -77,6 +77,36 @@ void test_ccnl_cs_add_invalid_parameters()
     assert_int_equal(result, CS_CONTENT_IS_INVALID);
 }
 
+void test_ccnl_cs_lookup_invalid_parameters()
+{
+    /** build up our ccnl_cs_name_t struct */
+    uint8_t _size = 10;
+    uint8_t _name[_size];
+    memset(&(_name[0]), 0x42, _size);  
+
+    /** set the name */
+    ccnl_cs_name_t name;
+    /** TODO: that's a bit hard to read -> fix */
+    name.name = &(_name[0]);
+    name.length = _size;
+            
+    ccnl_cs_content_t content;
+    int result = ccnl_cs_lookup(NULL, &name, &content);
+    /* if we pass an invalid ccnl_cs_ops_t array, call should fail */
+    assert_int_equal(result, CS_OPTIONS_ARE_NULL);
+
+    /* we don't initialize the function pointers */
+    ccnl_cs_ops_t options;
+
+    result = ccnl_cs_lookup(&options, NULL, &content);
+    /* if we pass an invalid name, call should fail */
+    assert_int_equal(result, CS_NAME_IS_INVALID);
+
+    result = ccnl_cs_lookup(&options, &name, NULL);
+    /* if we pass an invalid content object, call should fail */
+    assert_int_equal(result, CS_CONTENT_IS_INVALID);
+}
+
 void test_ccnl_cs_add_successful()
 {
     /** build up our ccnl_cs_name_t struct */
@@ -89,6 +119,7 @@ void test_ccnl_cs_add_successful()
     /** TODO: that's a bit hard to read -> fix */
     name.name = &(_name[0]);
     name.length = _size;
+
     ccnl_cs_content_t content;
     //TODO    
     int result = ccnl_cs_add(NULL, &name, &content);
@@ -200,6 +231,7 @@ int main(void)
          unit_test(test1),
          unit_test(test_ccnl_cs_remove_invalid_parameters),
          unit_test(test_ccnl_cs_add_invalid_parameters),
+         unit_test(test_ccnl_cs_lookup_invalid_parameters),
     /*
          unit_test(test_ccnl_cs_remove_invalid_name),
          unit_test(test_ccnl_cs_remove_wrong_name_size, setup, NULL),

--- a/test/ccnl-cs/test_cs.c
+++ b/test/ccnl-cs/test_cs.c
@@ -63,18 +63,18 @@ void test_ccnl_cs_add_invalid_parameters()
     ccnl_cs_content_t content;
     int result = ccnl_cs_add(NULL, &name, &content);
     /* if we pass an invalid ccnl_cs_ops_t array, call should fail */
-    assert_int_equal(result, -1);
+    assert_int_equal(result, CS_OPTIONS_ARE_NULL);
 
     /* we don't initialize the function pointers */
     ccnl_cs_ops_t options;
 
     result = ccnl_cs_add(&options, NULL, &content);
     /* if we pass an invalid name, call should fail */
-    assert_int_equal(result, -2);
+    assert_int_equal(result, CS_NAME_IS_INVALID);
 
     result = ccnl_cs_add(&options, &name, NULL);
     /* if we pass an invalid content object, call should fail */
-    assert_int_equal(result, -3);
+    assert_int_equal(result, CS_CONTENT_IS_INVALID);
 }
 
 void test_ccnl_cs_add_successful()
@@ -93,7 +93,7 @@ void test_ccnl_cs_add_successful()
     //TODO    
     int result = ccnl_cs_add(NULL, &name, &content);
     /* if we pass an invalid ccnl_cs_ops_t array, call should fail */
-    assert_int_equal(result, 0);
+    assert_int_equal(result, CS_OPERATION_WAS_SUCCESSFUL);
 }
 
 void test_ccnl_cs_add_unsuccessful()
@@ -112,7 +112,7 @@ void test_ccnl_cs_add_unsuccessful()
     //TODO    
     int result = ccnl_cs_add(NULL, &name, &content);
     /* if we pass an invalid ccnl_cs_ops_t array, call should fail */
-    assert_int_equal(result, 0);
+    assert_int_equal(result, CS_OPERATION_WAS_SUCCESSFUL);
 
     // and now try to add the same content again which should fail
 
@@ -132,14 +132,14 @@ void test_ccnl_cs_remove_invalid_parameters()
             
     int result = ccnl_cs_remove(NULL, &name);
     /* if we pass an invalid ccnl_cs_ops_t array, call should fail */
-    assert_int_equal(result, -1);
+    assert_int_equal(result, CS_OPTIONS_ARE_NULL);
 
     /* we don't set function pointers */
     ccnl_cs_ops_t options;
 
     result = ccnl_cs_remove(&options, NULL);
     /* if we pass an invalid name, call should fail */
-    assert_int_equal(result, -2);
+    assert_int_equal(result, CS_NAME_IS_INVALID);
 }
 
 void test_ccnl_cs_remove_wrong_name_size(void **state)


### PR DESCRIPTION
### Contribution description

This PR adds documentation to the header and return codes to the implementation of the new content store. We should check all parameters if they are null and return if the check fails (with a corresponding return code). I've also took the liberty to simplify the "{cont,name}len" members of the corresponding structs, i.e.
```C
ccnl_cs_content_t content;
...
content.contlen = 42;
```
seems redundant. Personally, I think the following is nicer to read
```C
ccnl_cs_content_t content;
...
content.length = 42;
```