### PR TITLE
Default PIT replacement behaviour

### DIFF
--- a/src/ccnl-core/include/ccnl-interest.h
+++ b/src/ccnl-core/include/ccnl-interest.h
@@ -27,6 +27,7 @@
 
 #include "ccnl-pkt.h"
 #include "ccnl-face.h"
+#include "ccnl-qos.h"
 
 #ifdef CCNL_RIOT
 #include "evtimer_msg.h"
@@ -50,6 +51,7 @@ struct ccnl_interest_s {
     struct ccnl_pkt_s *pkt;             /**< the packet the interests originates from (?) */
     struct ccnl_face_s *from;           /**< the face the interest was received from */
     struct ccnl_pendint_s *pending;     /**< linked list of faces wanting that content */
+    qos_traffic_class_t *tc;
     uint32_t lifetime;                  /**< interest lifetime */
     uint32_t last_used;                 /**< last time the entry was used */
     int retries;                        /**< current number of executed retransmits. */

--- a/src/ccnl-core/src/ccnl-interest.c
+++ b/src/ccnl-core/src/ccnl-interest.c
@@ -70,13 +70,13 @@ ccnl_interest_new(struct ccnl_relay_s *ccnl, struct ccnl_face_s *from,
     if (ccnl->pitcnt >= ccnl->max_pit_entries) {
         ccnl_prefix_to_str(i->pkt->pfx, s, CCNL_MAX_PREFIX_SIZE);
         qos_traffic_class_t *tclass = qos_traffic_class(s);
-        if (pit_strategy_remove(ccnl, i, tclass)) {
-            ccnl->pitcnt++;
-            ccnl_interest_remove(ccnl, i);
+        if (!pit_strategy_remove(ccnl, i, tclass)) {
+            // No PIT entry was removed, so we should discard this Interest
             return NULL;
         }
     }
 
+    // PIT entry was removed, so we can add the new entry
     DBL_LINKED_LIST_ADD(ccnl->pit, i);
 
     ccnl->pitcnt++;

--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -1079,6 +1079,21 @@ pit_strategy_remove(struct ccnl_relay_s *relay, struct ccnl_interest_s *i,
 {
     if (_pit_remove_func) {
         return _pit_remove_func(relay, i, tclass);
+    } else {
+        // If no PIT removal strategy defined, remove oldest PIT entry
+        struct ccnl_interest_s *cur = relay->pit;
+        struct ccnl_interest_s *oldest = cur;
+
+        while (cur) {
+            if (cur->last_used < oldest->last_used) {
+                oldest = cur;
+            }
+        }
+
+        ccnl_interest_remove(relay, oldest);
+
+        return 1;
     }
+
     return 0;
 }


### PR DESCRIPTION
The default PIT replacement strategy (implemented in `ccnl-relay.c` and called if `_pit_remove_func` is not defined) is LRU.

If the user-defined PIT replacements strategy returns 0, nothing is replaced and the incoming Interest is discarded. The default strategy never returns 0.

Also added a QoS traffic class member to `ccnl_interest_s` to allow the PIT to keep track of pending interests' service classes.